### PR TITLE
Changed implement to enforce to promote action

### DIFF
--- a/2_planning_events.md
+++ b/2_planning_events.md
@@ -7,7 +7,7 @@
 * Ensure correct information to book travel for speakers or issue honorariums. Not everyone has a government ID in the same name they use publicly
 * Include topics regarding trans and non-binary people matter of factly — we are part of life
 * Vet speakers for biased language and content — check with community members regarding prior engagements
-* Have inclusive Code of Conduct ([1](https://medium.com/r/?url=https://donutjs.club/conduct/), [2](https://medium.com/r/?url=https://www.recurse.com/code-of-conduct)) prepared that you feel prepared to implement
+* Have an inclusive Code of Conduct ([1](https://donutjs.club/conduct/), [2](https://www.recurse.com/code-of-conduct)) that you feel prepared to enforce
 * Plan for pronouns stickers, buttons or tags for everyone as part of the registration process — not just for use by trans or non-binary folks
 * Don’t ask minority speakers to only speak about minority issues — they have other skills too
 * Ask community members what they need instead of assuming


### PR DESCRIPTION
Implementing a CoC is one thing, enforcing it is another. As event organisers we should be comfortable enforcing the things we say we stand for. I feel this change enforces (ha) that.