### PR TITLE
Reword/correct links

### DIFF
--- a/5_resources.md
+++ b/5_resources.md
@@ -1,12 +1,18 @@
 ## resources
 
 
-* Trans 101: [bit.ly/TRANS_101](bit.ly/TRANS_101)
-* non-binary, AGENDER, ETC: [bit.ly/non-binary](it.ly/non-binary)
-* Why we are discussing trans issues in “women’s” spaces: [bit.ly/DISCUSS_SPACES](bit.ly/DISCUSS_SPACES)
-* An Incomplete Guide to Inclusive Language for Startups and Tech: [bit.ly/VOCABGUIDE](bit.ly/VOCABGUIDE)
-* Diversity Stock Photography: [bit.ly/STOCKPHOTO](bit.ly/STOCKPHOTO)
-* HRC Toolkit: [bit.ly/HRCSTUDY](bit.ly/STOCKPHOTO)
-* Two great code-of-conduct examples Code of Conduct ([1](https://medium.com/r/?url=https://donutjs.club/conduct/), [2](https://medium.com/r/?url=https://www.recurse.com/code-of-conduct))
-* Recurse Center Social Rules for [managing microaggressions](https://www.recurse.com/manual)
-* How diversity benefits teams (primary source) ([1](https://www.mckinsey.com/business-functions/organization/our-insights/why-diversity-matters),[2](https://www.msci.com/documents/10199/04b6f646-d638-4878-9c61-4eb91748a82b),[3](http://gap.hks.harvard.edu/impact-gender-diversity-performance-business-teams-evidence-field-experiment),[4](https://www.gsb.stanford.edu/insights/diversity-work-group-performance)).
+* [Trans 101](https://everydayfeminism.com/2016/08/transgender-101/) / [bit.ly/TRANS_101](https://bit.ly/TRANS_101)
+* [Nonbinary, agender, etc](https://nonbinary.wiki/wiki/Main_Page)
+* [Why we are discussing trans issues in “women’s” spaces (PDF)](http://www.transstudent.org/admissionspolicy.pdf) / [bit.ly/DISCUSS_SPACES](https://bit.ly/DISCUSS_SPACES)
+* [An Incomplete Guide to Inclusive Language for Startups and Tech](https://open.buffer.com/inclusive-language-tech/) / [bit.ly/VOCABGUIDE](https://bit.ly/VOCABGUIDE)
+* [Diversity Stock Photography](https://askwelmoed.com/free-paid-stockphotos-diversity-in-ethnicity-sexuality-gender-age-and-ability/) / [bit.ly/STOCKPHOTO](https://bit.ly/STOCKPHOTO)
+* [HRC Toolkit](http://www.hrc.org/resources/the-cost-of-the-closet-and-the-rewards-of-inclusion) / [bit.ly/HRCSTUDY](https://bit.ly/HRCSTUDY)
+* Two great Code of Conduct examples:
+  * [DonutJS](https://donutjs.club/conduct/)
+  * [Recurse](https://www.recurse.com/code-of-conduct)
+* Recurse Center Social Rules for [managing microaggressions](https://www.recurse.com/manual#sub-sec-social-rules)
+* How diversity benefits teams:
+  * [Why diversity matters](https://www.mckinsey.com/business-functions/organization/our-insights/why-diversity-matters) by Vivian Hunt, Dennis Layton, and Sara Prince
+  * [Global trends in gender diversity on corporate boards (PDF)](https://www.msci.com/documents/10199/04b6f646-d638-4878-9c61-4eb91748a82b) by Linda-Eling Lee, Ric Marshall, Damion Rallis, and Matt Moscardi
+  * [The Impact of Gender Diversity on the Performance of Business Teams: Evidence from a Field Experiment](http://gap.hks.harvard.edu/impact-gender-diversity-performance-business-teams-evidence-field-experiment) by Sander Hoogendoorn, Hessel Oosterbeek, and Mirjam van Praag
+  * [Diversity and Work Group Performance](https://www.gsb.stanford.edu/insights/diversity-work-group-performance) by Stanford GSB Staff


### PR DESCRIPTION
The non-binary bit.ly was broken, so I replaced it with nonbinary.wiki, hope that's alright.

I left the bit.ly links in there just in case you wanted that. I'd suggest removing them as they kinda clutter up the page.